### PR TITLE
Add the bcmath PHP extension

### DIFF
--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && pecl install imagick \
     && docker-php-ext-enable imagick \
     && docker-php-ext-install \
+        bcmath \
         curl \
         iconv \
         mbstring \

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && pecl install imagick \
     && docker-php-ext-enable imagick \
     && docker-php-ext-install \
+        bcmath \
         curl \
         iconv \
         mbstring \

--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && pecl install imagick \
     && docker-php-ext-enable imagick \
     && docker-php-ext-install \
+        bcmath \
         curl \
         iconv \
         mbstring \


### PR DESCRIPTION
Since the bcmath is one of [Laravel's required PHP extension](https://laravel.com/docs/6.0/installation#server-requirements), I think we should add it.